### PR TITLE
Update package.js so simple-schema can support Meteor 0.6.5

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,4 +10,5 @@ Package.on_use(function(api) {
 Package.on_test(function(api) {
     api.use(["meteor-simple-schema", "tinytest", "test-helpers"]);
     api.add_files("simple-schema-tests.js", ['client', 'server']);
+    api.export(['SimpleSchema', 'SchemaRegEx'], ['client', 'server']);
 });


### PR DESCRIPTION
I am using _collection2_ which depend on _simple-schema_, when upgrade to Meteor 0.6.5, collection2 has been broken because we must manually export what global variable we want. 

More info here
Follow up https://docs.meteor.com/#writingpackages

Fix here
`api.export(['SimpleSchema', 'SchemaRegEx'], ['client', 'server']);`
