### PR TITLE
Add the ability to stringify a SimpleSchema (add a toJSON method)

### DIFF
--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -951,3 +951,21 @@ Tinytest.add("SimpleSchema - Update Allowed Values Check", function(test) {
         }});
     test.isTrue(ss.invalidKeys().length === 1);
 });
+
+Tinytest.add("SimpleSchema - JSON stringify", function(test) {
+    test.equal(JSON.stringify(ss), '{"string":{"optional":true},"minMaxStr' +
+        'ing":{"optional":true,"min":10,"max":20},"minMaxStringArray":{"ty' +
+        'pe":[null],"optional":true,"min":10,"max":20,"minCount":1,"maxCou' +
+        'nt":2},"allowedStrings":{"optional":true,"allowedValues":["tuna",' +
+        '"fish","salad"]},"valueIsAllowedString":{"optional":true},"allowe' +
+        'dStringsArray":{"type":[null],"optional":true,"allowedValues":["t' +
+        'una","fish","salad"]},"boolean":{"optional":true},"number":{"opti' +
+        'onal":true},"minMaxNumber":{"optional":true,"min":10,"max":20},"a' +
+        'llowedNumbers":{"optional":true,"allowedValues":[1,2,3]},"valueIs' +
+        'AllowedNumber":{"optional":true},"allowedNumbersArray":{"type":[n' +
+        'ull],"optional":true,"allowedValues":[1,2,3]},"decimal":{"optiona' +
+        'l":true,"decimal":true},"date":{"optional":true},"minMaxDate":{"o' +
+        'ptional":true,"min":"2013-01-01T00:00:00.000Z","max":"2013-12-31T' +
+        '00:00:00.000Z"},"email":{"regEx":{},"optional":true},"url":{"regE' +
+        'x":{},"optional":true}}');
+});

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -75,6 +75,11 @@ checkSchema = function(/*arguments*/) {
     }
 };
 
+//return a copy of the schema for (E)JSON stringification
+SimpleSchema.prototype.toJSON = function() {
+    return _.clone(this._schema);
+};
+
 //validates doc against self._schema and sets a reactive array of error objects
 SimpleSchema.prototype.validate = function(doc) {
     var self = this, invalidKeys = [];


### PR DESCRIPTION
This can be useful to send a SimpleSchema over the wire.
`toJSON` is a standard name (see https://developer.mozilla.org/en-US/docs/JSON#toJSON()_method)
