### PR TITLE
Accept a SimpleSchema as a valid argument for the check function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ A simple, reactive schema validation smart package for Meteor.
 
 ## Change Log
 
+### next
+
+* A SimpleSchema object is now a valid second parameter for the build-in `check` and `Match.test` functions
+* `.match()` method is deprecated
+
 ### 0.1.12
 
 Return true from `match()`

--- a/README.md
+++ b/README.md
@@ -186,9 +186,16 @@ is returned.
 Call `MySchema.resetValidation()` if you need to reset the SimpleSchema object,
 clearing out any invalid field messages.
 
-Call `MySchema.match()` to return a match function that can be passed as the 
-second argument of the built-in `check()` function. This will throw a Match.Error
-if the object specified in the first argument is not valid according to the schema.
+A schema can be passed as the second argument of the built-in `check()` function. 
+This will throw a Match.Error if the object specified in the first argument is not
+valid according to the schema. It works with `Match.test` as well:
+```js
+var mySchema = new SimpleSchema({name: {type: String}});
+
+Match.test({name: 'Steve'}, mySchema); // Return true
+Match.test({admin: true}, mySchema); // Return false
+check({admin: true}, mySchema); // throw a Match.Error
+```
 
 ### The Object
 

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -1050,3 +1050,14 @@ Tinytest.add("SimpleSchema - Validate Against Another Key", function(test) {
     test.isTrue(pss.invalidKeys().length === 1);
 
 });
+
+Tinytest.add("SimpleSchema - Validate with the Match API", function(test) {
+
+    test.isTrue(pss instanceof SimpleSchema);
+    test.isFalse(Match.test({password: 'pass'}, pss));
+    test.isTrue(Match.test({password: 'pass', confirmPassword: 'pass'}, pss));
+
+    // [backwards compatibility]
+    test.isFalse(Match.test({password: 'pass'}, pss.match()));
+    test.isTrue(Match.test({password: 'pass', confirmPassword: 'pass'}, pss.match()));
+});

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -53,8 +53,26 @@ SimpleSchema = function(schema) {
     });
 };
 
-//return a function that can be use as the second parameter of the build-in check function
+// Inherit from Match.Where
+// This allow SimpleSchema instance to be recognized as a Match.Where instance as well
+// as a SimpleSchema instance
+SimpleSchema.prototype = new Match.Where()
+
+// If an object is an instance of Match.Where, Meteor build-in check API will look at
+// the function named `condition` and will pass it the document to validate
+SimpleSchema.prototype.condition = function(doc) {
+    var self = this;
+    self.validate(doc);
+    if (!self.valid())
+        throw new Match.Error("One or more properties do not match the schema.");
+    return true
+}
+
+// [backwards compatibility]
+// return a function that can be use as the second parameter of the build-in check function
 SimpleSchema.prototype.match = function() {
+    console.warn('There is no more need to call the .match() method on a object to check it.');
+    console.warn('see https://github.com/aldeed/meteor-simple-schema#other-methods');
     var self = this;
     return Match.Where(function(doc) {
         self.validate(doc);
@@ -65,10 +83,12 @@ SimpleSchema.prototype.match = function() {
     });
 };
 
-//backwards compatibility checkSchema - exported
+// [backwards compatibility]
+// checkSchema - exported
 checkSchema = function(/*arguments*/) {
     console.warn('checkSchema is obsolete. Please have a look at the simple-schema documentation.');
     console.warn('https://github.com/aldeed/meteor-simple-schema#other-methods');
+    
     var args = _.toArray(arguments);
     if (!args || !_.isObject(args[0]) || !args[1] instanceof SimpleSchema) {
         throw new Error("Invalid arguments");


### PR DESCRIPTION
In #7, @aldeed and I suggested to extend the Meteor build-in `check()` function to support `SimpleSchema` without having to call the `.match()` method on it.
While working on this PR for the Meteor core project, I've found that it was actually not needed.

This PR basically add this single line:

``` js
SimpleSchema.prototype = new Match.Where()
```

With this, a SimpleSchema object is now recognized as a kind of "subclass" of `Meteor.Where`, and as a result it's now a valid argument for both `check()` and `Match.test()`.

Related links:
- https://github.com/meteor/meteor/blob/devel/packages/check/match.js#L175
- http://stackoverflow.com/questions/2449254/what-is-the-instanceof-operator-in-javascript
