### PR TITLE
isModified, empty object check [bugfix]

### DIFF
--- a/simple-schema-context.js
+++ b/simple-schema-context.js
@@ -427,6 +427,9 @@ var doValidation = function(doc, isModifier, isUpsert, keyToValidate, ss, schema
   }
 
   if (isModifier) {
+    if (_.isEmpty(doc)) {
+      throw new Error("When the modifier option is true, validation object must have at least one operator");
+    }
     //second, loop through present modifiers
     _.each(doc, function(modObj, operator) {
       if (operator.substring(0, 1) !== "$") {


### PR DESCRIPTION
Throw exceptions in next situation:

CollectionName.update(someId, { $set: { nonexistentKey: anyValue } });

Otherwise object will be updated to { "_id": "someId" }
In other words, object will be rewritten by empty object.
