### PR TITLE
AutoConvert type Number with Number() not parseFloat()

### DIFF
--- a/simple-schema.js
+++ b/simple-schema.js
@@ -371,11 +371,11 @@ var typeconvert = function(value, type) {
     return value;
   }
   if (type === Number) {
-    if (typeof value === "string") {
+    if (typeof value === "string" && !S(value).isEmpty()) {
       //try to convert numeric strings to numbers
-      var floatVal = parseFloat(value);
-      if (!isNaN(floatVal)) {
-        return floatVal;
+      var numberVal = Number(value);
+      if (!isNaN(numberVal)) {
+        return numberVal;
       } else {
         return value; //leave string; will fail validation
       }


### PR DESCRIPTION
parseFloat(’17:25.9’) === 17
Number(’17:25.9’) === NaN
parseFloat(’1typo7’) === 1
Number(’1typo7’) === NaN

I believe receiving a ‘must be a number’ error message when entering ‘1typo7’ makes more sense than autoConverting it to 1.

http://stackoverflow.com/questions/12227594/which-is-better-numberx-or-parsefloatx
