### PR TITLE
Escape untrusted value to allow html tags in error messages

### DIFF
--- a/simple-schema.js
+++ b/simple-schema.js
@@ -261,7 +261,7 @@ SimpleSchema.prototype.messageForError = function(type, key, def, value) {
     message = message.replace("[maxCount]", def.maxCount);
   }
   if (value !== void 0 && value !== null) {
-    message = message.replace("[value]", value.toString());
+    message = message.replace("[value]", S(value.toString()).escapeHTML().s);
   }
   var min = def.min;
   var max = def.max;


### PR DESCRIPTION
```
SimpleSchema.messages({
  expectedNumber: “<strong>[value]</strong> must be a number"
});
```

This small change would allow html tags within the error message itself
to rendered without also rendering any html tags that may have been
included in a value by a nefarious user.
