### PR TITLE
Consistently use _.isArray to check if variable is an array.

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -163,7 +163,7 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
         subkey = subkey.slice(0, -1);
       }
       current = current[subkey];
-      if (!isArray(current) && !isBasicObject(current) && i < ln - 1) {
+      if (!_.isArray(current) && !isBasicObject(current) && i < ln - 1) {
         return;
       }
     }
@@ -208,7 +208,7 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
         current = current[subkey];
 
         // If we can go no further, then quit
-        if (!isArray(current) && !isBasicObject(current) && i < ln - 1) {
+        if (!_.isArray(current) && !isBasicObject(current) && i < ln - 1) {
           return;
         }
       }
@@ -677,9 +677,7 @@ MongoObject._positionToKey = function positionToKey(position) {
   return key;
 };
 
-var isArray = Array.isArray || function(obj) {
-  return obj.toString() === '[object Array]';
-};
+var isArray = _.isArray;
 
 var isObject = function(obj) {
   return obj === Object(obj);


### PR DESCRIPTION
This caused an error in IE. I kept the "var isArray" function, in case that other code uses it, but internally the MongoObject now consistently uses the underscore "isArray" function. I hope that this helps, as I wasn't sure if you had a specific reason to no use the underscore version in some cases.
