### PR TITLE
Updated error message

### DIFF
--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -14,7 +14,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
         return (k.substring(0, 1) === "$");
       });
       if (!allKeysAreOperators) {
-        throw new Error("When the modifier option is true, all validation object keys must be operators");
+        throw new Error("When the modifier option is true, all validation object keys must be operators. Did you forget `$set`?");
       }
 
       // Get a list of all keys in $set and $setOnInsert combined, for use later


### PR DESCRIPTION
I did something stupid here and forget to add `$set` operator to my update query. Before I used simple-schema I'd catch such errors pretty fast, but now I get the extremely cryptic error message. I had completely no idea what is the modifier option, where was it set, what are "validation object keys" and what does the "operator" mean here. Once I debugged all of this and find the cause I realized my mistake and what all those words mean, but it cost me over an hour. This could easily be avoided by more user-facing and less code-facing error message.
