### PR TITLE
Object + blackbox + property with decimal prefix = fail

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -745,3 +745,4 @@ var extractOp = function extractOp(position) {
   var firstPositionPiece = position.slice(0, position.indexOf("["));
   return (firstPositionPiece.substring(0, 1) === "$") ? firstPositionPiece : null;
 };
+


### PR DESCRIPTION
Hi,

This is a fix to following case:

items: {
    type: Object,
    blackbox: true,
}

When I try to update property items.EvGQ2QcthzjiPCcat.price then everything goes well.
But when I try to update property items.7vGQ2QcthzjiPCcat.price then I have an error:

SimpleSchema.clean: filtered out value that would have affected key "items.$vGQ2QcthzjiPCcat.price", which is not allowed by the schema

Cheers!
