### PR TITLE
Don't validate type and allowed values if we have a custom validator

### DIFF
--- a/package.js
+++ b/package.js
@@ -38,7 +38,7 @@ Package.on_test(function(api) {
     api.use("aldeed:simple-schema");
     api.use('tinytest@1.0.0');
     api.use('test-helpers@1.0.0');
-    api.use('check', 'underscore');
+    api.use(['check', 'underscore']);
   } else {
     api.use(["simple-schema", "tinytest", "test-helpers"]);
   }

--- a/package.js
+++ b/package.js
@@ -38,6 +38,7 @@ Package.on_test(function(api) {
     api.use("aldeed:simple-schema");
     api.use('tinytest@1.0.0');
     api.use('test-helpers@1.0.0');
+    api.use('check', 'underscore');
   } else {
     api.use(["simple-schema", "tinytest", "test-helpers"]);
   }

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -51,18 +51,20 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
     if (op !== "$unset" && op !== "$rename" && Utility.isNotNullOrUndefined(val)) {
 
       // Check that value is of the correct type
-      var typeError = doTypeChecks(def, val, op);
-      if (typeError) {
-        invalidKeys.push(Utility.errorObject(typeError, affectedKey, val, def, ss));
-        return;
-      }
+      if (! def.custom) {
+        var typeError = doTypeChecks(def, val, op);
+        if (typeError) {
+          invalidKeys.push(Utility.errorObject(typeError, affectedKey, val, def, ss));
+          return;
+        }
 
-      // Check value against allowedValues array
-      if (def.allowedValues && !_.contains(def.allowedValues, val)) {
-        invalidKeys.push(Utility.errorObject("notAllowed", affectedKey, val, def, ss));
-        return;
-      }
+        // Check value against allowedValues array
+        if (def.allowedValues && !_.contains(def.allowedValues, val)) {
+          invalidKeys.push(Utility.errorObject("notAllowed", affectedKey, val, def, ss));
+          return;
+        }
 
+      }
     }
 
     // Perform custom validation

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -500,7 +500,7 @@ SimpleSchema._globalMessages = {
     {exp: SimpleSchema.RegEx.Url, msg: "[label] must be a valid URL"},
     {exp: SimpleSchema.RegEx.Id, msg: "[label] must be a valid alphanumeric ID"}
   ],
-  keyNotInSchema: "[label] is not allowed by the schema"
+  keyNotInSchema: "[key] is not allowed by the schema"
 };
 
 SimpleSchema.messages = function(messages) {
@@ -606,8 +606,9 @@ SimpleSchema.prototype.messageForError = function(type, key, def, value) {
   // Now replace all placeholders in the message with the correct values
 
   // [label]
-  self._depsLabels[key] && self._depsLabels[key].depend(); // React to label changes
-  message = message.replace("[label]", def.label);
+  // self._depsLabels[key] && self._depsLabels[key].depend(); // React to label changes
+  message = message.replace("[key]", def.key);
+  message = message.replace("[label]", self.label(key));
 
   // [minCount]
   if (typeof def.minCount !== "undefined") {

--- a/versions.json
+++ b/versions.json
@@ -38,6 +38,6 @@
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.35",
+  "toolVersion": "meteor-tool@1.0.36",
   "format": "1.0"
 }

--- a/versions.json
+++ b/versions.json
@@ -22,7 +22,7 @@
     ],
     [
       "meteor",
-      "1.1.2"
+      "1.1.3"
     ],
     [
       "random",
@@ -38,6 +38,6 @@
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.34",
+  "toolVersion": "meteor-tool@1.0.35",
   "format": "1.0"
 }


### PR DESCRIPTION
If you have a custom validator, you'd like to handle these on your own.  And it's also really hard to get around simple schema's default behavior in regard to types if you want to.  This makes that possible using the existing custom validator logic.