### PR TITLE
bug fix

### DIFF
--- a/simple-schema.js
+++ b/simple-schema.js
@@ -567,7 +567,7 @@ SimpleSchema._makeGeneric = function(name) {
     return null;
   }
 
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+/g, '.$');
+  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+$/, '.$');
 };
 
 SimpleSchema._depsGlobalMessages = new Deps.Dependency();


### PR DESCRIPTION
I used mongo document ID as property name. Sometimes the document ID starts with a number, which will be incorrectly replaced with a '$' due to a small mistake in _makeGeneric's regular expression. 

Causing further issues downstream in schema.clean()

Example:
`SimpleSchema.clean: filtered out value that would have affected key "roles.$smTTdHqxAsR54bw4", which is not allowed by the schema`