### PR TITLE
Capitalize labels properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ expecting an array of values of that type.
 
 A string that will be used to refer to this field in validation error messages.
 The default is an inflected (humanized) derivation of the key name itself. For
-example, the key "firstName" will have a default label of "First name".
+example, the key "firstName" will have a default label of "First Name".
 
 If you require a field that changes its meaning in some
 circumstances you can provide a callback function as a label.

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -3184,8 +3184,8 @@ Tinytest.add("SimpleSchema - Nested Schemas", function(test) {
 
 Tinytest.add("SimpleSchema - Labels", function(test) {
   //inflection
-  test.equal(ss.label("minMaxNumber"), "Min max number", '"minMaxNumber" should have inflected to "Min max number" label');
-  test.equal(ssr.label("optionalObject.requiredString"), "Required string", '"optionalObject.requiredString" should have inflected to "Required string" label');
+  test.equal(ss.label("minMaxNumber"), "Min Max Number", '"minMaxNumber" should have inflected to "Min Max Number" label');
+  test.equal(ssr.label("optionalObject.requiredString"), "Required String", '"optionalObject.requiredString" should have inflected to "Required String" label');
 
   //dynamic
   ss.labels({"sub.number": "A different label"});
@@ -3317,7 +3317,7 @@ Tinytest.add("SimpleSchema - Built-In RegEx and Messages", function(test) {
 
   c1.validate({weakDomain: "///jioh779&%"});
   test.length(c1.invalidKeys(), 1);
-  test.equal(c1.keyErrorMessage("weakDomain"), "Weak domain must be a valid domain");
+  test.equal(c1.keyErrorMessage("weakDomain"), "Weak Domain must be a valid domain");
 
   c1.validate({ip: "foo"});
   test.length(c1.invalidKeys(), 1);

--- a/string.js
+++ b/string.js
@@ -54,7 +54,12 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
     },
 
     capitalize: function() {
-      return new S(this.s.substr(0, 1).toUpperCase() + this.s.substring(1).toLowerCase());
+      var words = this.s.split(' ');
+      var s = '';
+      for (var i = 0; i < words.length; i++) {
+        s += words[i].substr(0, 1).toUpperCase() + words[i].substr(1).toLowerCase() + ' ';
+      }
+      return new S(s).trim();
     },
 
     charAt: function(index) {
@@ -165,7 +170,7 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
     humanize: function() { //modified from underscore.string
       if (this.s === null || this.s === undefined)
         return new S('')
-      var s = this.underscore().replace(/_id$/,'').replace(/_/g, ' ').trim().capitalize()
+      var s = this.underscore().replace(/_/g, ' ').trim().capitalize()
       return new S(s)
     },
 


### PR DESCRIPTION
Removes explicit filtering of '_id' inside humanize function
Capitalizes labels properly
Fixes https://github.com/aldeed/meteor-simple-schema/issues/260
