### PR TITLE
Issue 216: Fix regexp in makeGeneric() + test

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -40,7 +40,7 @@ var makeGeneric = function makeGeneric(name) {
   if (typeof name !== "string") {
     return null;
   }
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+$/g, '.$');
+  return name.replace(/\.[0-9]+/g, '.$');
 };
 
 var appendAffectedKey = function appendAffectedKey(affectedKey, key) {

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -428,14 +428,37 @@ var reqCust = new SimpleSchema({
   }
 });
 
+var cell = new SimpleSchema({
+  row: {
+    type: Number
+  },
+  col: {
+    type: Number
+  },
+  letter: {
+    type: String
+  },
+  color: {
+    type: String,
+    optional: true
+  },
+  score: {
+    type: Number
+  }
+});
+
 var game = new SimpleSchema({
   field: {
-    type: Array
+    type: [Array],
+    optional: true
   },
   'field.$': {
     type: Array
   },
   'field.$.$': {
+    type: cell
+  }
+});
     type: Object
   },
   'field.$.$.requiredString': {
@@ -2846,8 +2869,39 @@ Tinytest.add("SimpleSchema - Array of Objects", function(test) {
 });
 
 Tinytest.add("SimpleSchema - Issue #216 (Array of Arrays of Objects)", function(test) {
-  var sc = validate(game, {$set: { field: [ [ {requiredString: 'lol'} ] ]}}, true);
-  console.log(sc.invalidKeys());
+  var sc = validate(game,
+    {
+      $set: {
+        field: [
+        [ { row: 0, col: 0, letter: 'к', score: 1, color: 'blue' },
+          { row: 0, col: 1, letter: 'л', score: 1, color: 'blue' },
+          { row: 0, col: 2, letter: 'с', score: 1, color: 'blue' },
+          { row: 0, col: 3, letter: 'ё', score: 1, color: 'blue' },
+          { row: 0, col: 4, letter: 'ю', score: 1, color: 'blue' } ],
+        [ { row: 1, col: 0, letter: 'л', score: 1, color: '' },
+          { row: 1, col: 1, letter: 'т', score: 1, color: '' },
+          { row: 1, col: 2, letter: 'ц', score: 1, color: '' },
+          { row: 1, col: 3, letter: 'щ', score: 1, color: '' },
+          { row: 1, col: 4, letter: 'ы', score: 1, color: '' } ],
+        [ { row: 2, col: 0, letter: 'ф', score: 1, color: '' },
+          { row: 2, col: 1, letter: 'щ', score: 1, color: '' },
+          { row: 2, col: 2, letter: 'х', score: 1, color: '' },
+          { row: 2, col: 3, letter: 'у', score: 1, color: '' },
+          { row: 2, col: 4, letter: 'ь', score: 1, color: '' } ],
+        [ { row: 3, col: 0, letter: 'л', score: 1, color: '' },
+          { row: 3, col: 1, letter: 'р', score: 1, color: '' },
+          { row: 3, col: 2, letter: 'р', score: 1, color: '' },
+          { row: 3, col: 3, letter: 'и', score: 1, color: '' },
+          { row: 3, col: 4, letter: 'с', score: 1, color: '' } ],
+        [ { row: 4, col: 0, letter: 'б', score: 1, color: 'green' },
+          { row: 4, col: 1, letter: 'р', score: 1, color: 'green' },
+          { row: 4, col: 2, letter: 'ь', score: 1, color: 'green' },
+          { row: 4, col: 3, letter: 'ъ', score: 1, color: 'green' },
+          { row: 4, col: 4, letter: 'й', score: 1, color: 'green' } ]
+        ]
+      }
+    }
+  , true);
   test.length(sc.invalidKeys(), 0);
 });
 

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -428,6 +428,22 @@ var reqCust = new SimpleSchema({
   }
 });
 
+var game = new SimpleSchema({
+  field: {
+    type: Array
+  },
+  'field.$': {
+    type: Array
+  },
+  'field.$.$': {
+    type: Object
+  },
+  'field.$.$.requiredString': {
+    type: String
+  }
+});
+
+
 /*
  * END SETUP FOR TESTS
  */
@@ -1925,7 +1941,7 @@ Tinytest.add("SimpleSchema - Minimum Checks - Insert", function(test) {
   test.length(sc.invalidKeys(), 1);
   /* NUMBER */
   sc = validate(ss, {
-    minMaxNumberExclusive: 20 
+    minMaxNumberExclusive: 20
   });
   test.length(sc.invalidKeys(), 1);
   sc = validate(ss, {
@@ -2827,6 +2843,12 @@ Tinytest.add("SimpleSchema - Array of Objects", function(test) {
       friends: {$each: [{name: "Bob", type: 2}, {name: "Bobby", type: "best"}]}
     }}, true);
   test.length(sc.invalidKeys(), 2);
+});
+
+Tinytest.add("SimpleSchema - Issue #216 (Array of Arrays of Objects)", function(test) {
+  var sc = validate(game, {$set: { field: [ [ {requiredString: 'lol'} ] ]}}, true);
+  console.log(sc.invalidKeys());
+  test.length(sc.invalidKeys(), 0);
 });
 
 Tinytest.add("SimpleSchema - Multiple Contexts", function(test) {

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -567,7 +567,7 @@ SimpleSchema._makeGeneric = function(name) {
     return null;
   }
 
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+/g, '.$');
+  return name.replace(/\.[0-9]+/g, '.$');
 };
 
 SimpleSchema._depsGlobalMessages = new Deps.Dependency();


### PR DESCRIPTION
`name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+$/g, '.$')` breaks on paths like `"field.$.$.requiredString"` because `.0.0.` only first `.0.` matches, not second `0.` (dot is "eaten" by first match.
I think one replace `/\.[0-9]+/` will work, because key-names not beginning with digit.