### PR TITLE
Set nested optional

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -40,7 +40,7 @@ var makeGeneric = function makeGeneric(name) {
   if (typeof name !== "string") {
     return null;
   }
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+$/g, '.$');
+  return name.replace(/\.[0-9]+/g, '.$');
 };
 
 var appendAffectedKey = function appendAffectedKey(affectedKey, key) {

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -459,10 +459,17 @@ var game = new SimpleSchema({
     type: cell
   }
 });
+
+var optionalInObject = new SimpleSchema({
+  obj: {
     type: Object
   },
-  'field.$.$.requiredString': {
-    type: String
+  'obj.string': {
+    type: String,
+    optional: true
+  },
+  'obj.num': {
+    type: Number
   }
 });
 
@@ -965,6 +972,16 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
 Tinytest.add("SimpleSchema - Required Checks - Update - Valid - $set", function(test) {
   var sc = validateNoClean(ssr, {$set: {}}, true);
   test.equal(sc.invalidKeys(), []); //would not cause DB changes, so should not be an error
+
+  sc = validate(optionalInObject, {$set:
+    {
+      obj: {
+        string: '',
+        num: 1
+      }
+    }
+  }, true);
+  test.length(sc.invalidKeys(), 0)
 
   sc = validateNoClean(ssr, {$set: {
       requiredString: "test",

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -428,14 +428,37 @@ var reqCust = new SimpleSchema({
   }
 });
 
+var cell = new SimpleSchema({
+  row: {
+    type: Number
+  },
+  col: {
+    type: Number
+  },
+  letter: {
+    type: String
+  },
+  color: {
+    type: String,
+    optional: true
+  },
+  score: {
+    type: Number
+  }
+});
+
 var game = new SimpleSchema({
   field: {
-    type: Array
+    type: [Array],
+    optional: true
   },
   'field.$': {
     type: Array
   },
   'field.$.$': {
+    type: cell
+  }
+});
     type: Object
   },
   'field.$.$.requiredString': {
@@ -2846,8 +2869,39 @@ Tinytest.add("SimpleSchema - Array of Objects", function(test) {
 });
 
 Tinytest.add("SimpleSchema - Issue #216 (Array of Arrays of Objects)", function(test) {
-  var sc = validate(game, {$set: { field: [ [ {requiredString: 'lol'} ] ]}}, true);
-  console.log(sc.invalidKeys());
+  var sc = validate(game,
+    {
+      $set: {
+        field: [
+        [ { row: 0, col: 0, letter: 'к', score: 1, color: 'blue' },
+          { row: 0, col: 1, letter: 'л', score: 1, color: 'blue' },
+          { row: 0, col: 2, letter: 'с', score: 1, color: 'blue' },
+          { row: 0, col: 3, letter: 'ё', score: 1, color: 'blue' },
+          { row: 0, col: 4, letter: 'ю', score: 1, color: 'blue' } ],
+        [ { row: 1, col: 0, letter: 'л', score: 1, color: '' },
+          { row: 1, col: 1, letter: 'т', score: 1, color: '' },
+          { row: 1, col: 2, letter: 'ц', score: 1, color: '' },
+          { row: 1, col: 3, letter: 'щ', score: 1, color: '' },
+          { row: 1, col: 4, letter: 'ы', score: 1, color: '' } ],
+        [ { row: 2, col: 0, letter: 'ф', score: 1, color: '' },
+          { row: 2, col: 1, letter: 'щ', score: 1, color: '' },
+          { row: 2, col: 2, letter: 'х', score: 1, color: '' },
+          { row: 2, col: 3, letter: 'у', score: 1, color: '' },
+          { row: 2, col: 4, letter: 'ь', score: 1, color: '' } ],
+        [ { row: 3, col: 0, letter: 'л', score: 1, color: '' },
+          { row: 3, col: 1, letter: 'р', score: 1, color: '' },
+          { row: 3, col: 2, letter: 'р', score: 1, color: '' },
+          { row: 3, col: 3, letter: 'и', score: 1, color: '' },
+          { row: 3, col: 4, letter: 'с', score: 1, color: '' } ],
+        [ { row: 4, col: 0, letter: 'б', score: 1, color: 'green' },
+          { row: 4, col: 1, letter: 'р', score: 1, color: 'green' },
+          { row: 4, col: 2, letter: 'ь', score: 1, color: 'green' },
+          { row: 4, col: 3, letter: 'ъ', score: 1, color: 'green' },
+          { row: 4, col: 4, letter: 'й', score: 1, color: 'green' } ]
+        ]
+      }
+    }
+  , true);
   test.length(sc.invalidKeys(), 0);
 });
 

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -428,6 +428,22 @@ var reqCust = new SimpleSchema({
   }
 });
 
+var game = new SimpleSchema({
+  field: {
+    type: Array
+  },
+  'field.$': {
+    type: Array
+  },
+  'field.$.$': {
+    type: Object
+  },
+  'field.$.$.requiredString': {
+    type: String
+  }
+});
+
+
 /*
  * END SETUP FOR TESTS
  */
@@ -1925,7 +1941,7 @@ Tinytest.add("SimpleSchema - Minimum Checks - Insert", function(test) {
   test.length(sc.invalidKeys(), 1);
   /* NUMBER */
   sc = validate(ss, {
-    minMaxNumberExclusive: 20 
+    minMaxNumberExclusive: 20
   });
   test.length(sc.invalidKeys(), 1);
   sc = validate(ss, {
@@ -2827,6 +2843,12 @@ Tinytest.add("SimpleSchema - Array of Objects", function(test) {
       friends: {$each: [{name: "Bob", type: 2}, {name: "Bobby", type: "best"}]}
     }}, true);
   test.length(sc.invalidKeys(), 2);
+});
+
+Tinytest.add("SimpleSchema - Issue #216 (Array of Arrays of Objects)", function(test) {
+  var sc = validate(game, {$set: { field: [ [ {requiredString: 'lol'} ] ]}}, true);
+  console.log(sc.invalidKeys());
+  test.length(sc.invalidKeys(), 0);
 });
 
 Tinytest.add("SimpleSchema - Multiple Contexts", function(test) {

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -123,7 +123,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
     if (!skipRequiredCheck && !def.optional) {
       if (
         val === null ||
-        op === "$unset" ||
+        op === "$unset" && def.type !== Object||
         op === "$rename" ||
         (val === void 0 && (isInArrayItemObject || isInSubObject || !op || op === "$set"))
         ) {
@@ -247,7 +247,13 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
       // Check all present keys plus all keys defined by the schema.
       // This allows us to detect extra keys not allowed by the schema plus
       // any missing required keys, and to run any custom functions for other keys.
-      var keysToCheck = _.union(presentKeys, ss.objectKeys(affectedKeyGeneric));
+
+      if (operator == '$unset') {
+        var keysToCheck = presentKeys
+      }
+      else {
+        var keysToCheck = _.union(presentKeys, ss.objectKeys(affectedKeyGeneric));
+      }
 
       // If this object is within an array, make sure we check for
       // required as if it's not a modifier

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -567,7 +567,7 @@ SimpleSchema._makeGeneric = function(name) {
     return null;
   }
 
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+/g, '.$');
+  return name.replace(/\.[0-9]+/g, '.$');
 };
 
 SimpleSchema._depsGlobalMessages = new Deps.Dependency();


### PR DESCRIPTION
Found the bug: when I 
```
$set {requiredObj: {requiredField: 'blah', optionalField: '' } }
```
It makes clean(), and modifier becomes: 
```
$set: {requiredObj: {requiredField: 'blah'}}, 
$unset: {requiredObj: {optionalField: undefined}}
```
and it fails on validation of requiredObj / $unset operation. But it shouldnt, because it will fail if some nested validations fails. If they optional, we shouldnt 