### PR TITLE
autoValue hooks not firing on subschemas on $set - Fix to issue #222

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -404,6 +404,39 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
   };
 
   /**
+   * @method MongoObject.getPositionsForGenericKeyUnderArray
+   * @param {String} key - Generic key
+   * @returns {String[]} Array of position strings
+   *
+   * Returns an array of position strings for the places in the object that
+   * affect the requested generic key.
+   * This version handles objects under an array, whereby the position needs
+   * to be split at the $ sign
+   * Example: ['foo[bar][0]']
+   */
+  self.getPositionsForGenericKeyUnderArray = function(key) {
+    // Get the info
+    var list = [];
+    for (var position in self._genericAffectedKeys) {
+      if (self._genericAffectedKeys.hasOwnProperty(position)) {
+        var keyToMatch = self._genericAffectedKeys[position];
+        if (keyToMatch.indexOf("$") !== -1) {
+          var testField = keyToMatch.slice(0, keyToMatch.lastIndexOf("$") + 1);
+          if (testField === key) {
+            list.push(testField);
+          }
+        } else {
+          if (keyToMatch === key) {
+            list.push(position);
+          }
+        }
+      }
+    }
+
+    return list;
+  };
+
+  /**
    * @deprecated Use getInfoForKey
    * @method MongoObject.getValueForKey
    * @param {String} key - Non-generic key
@@ -752,4 +785,3 @@ MongoObject._positionToKey = function positionToKey(position) {
   mDoc = null;
   return key;
 };
-

--- a/mongo-object.js
+++ b/mongo-object.js
@@ -422,8 +422,9 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
         var keyToMatch = self._genericAffectedKeys[position];
         if (keyToMatch.indexOf("$") !== -1) {
           var testField = keyToMatch.slice(0, keyToMatch.lastIndexOf("$") + 1);
+          var remainder = keyToMatch.slice(keyToMatch.lastIndexOf("$") + 1);
           if (testField === key) {
-            list.push(testField);
+            list.push(MongoObject._dropKeyOffEndOfPosition(position, remainder));
           }
         } else {
           if (keyToMatch === key) {
@@ -784,4 +785,23 @@ MongoObject._positionToKey = function positionToKey(position) {
   var key = mDoc.getKeyForPosition(position);
   mDoc = null;
   return key;
+};
+
+/**
+ * @method MongoObject._dropKeyOffEndOfPosition
+ * @param {String} position
+ * @param {String} keyToDrop
+ * @returns {String} The position, less the key component of that position
+ *
+ */
+MongoObject._dropKeyOffEndOfPosition = function dropKeyOffEndOfPosition(position, keyToDrop) {
+  //XXX Probably a better way to do this, but this is
+  //foolproof for now.
+  keyToDrop = keyToDrop.replace(/^\./, '');
+  if (keyToDrop.length === 0) {
+    return position;
+  }
+
+  var subString = MongoObject._keyToPosition(keyToDrop, true);
+  return position.replace(subString, '');
 };

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -388,7 +388,7 @@ function getAutoValues(mDoc, isModifier, extendedAutoValueContext) {
       keySuffix = fieldName.slice(testField.length + 1);
       positionSuffix = MongoObject._keyToPosition(keySuffix, true);
       keySuffix = '.' + keySuffix;
-      positions = mDoc.getPositionsForGenericKey(testField);
+      positions = mDoc.getPositionsForGenericKeyUnderArray(testField);
     } else {
 
       // See if anything in the object affects this key


### PR DESCRIPTION
Proposed fix for https://github.com/aldeed/meteor-simple-schema/issues/222

Issue whereby autoValue hooks for subdocuments don't run on a $set