### PR TITLE
Pass object as last arg of pick in order to declare new/overwrite existing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ var profileSchema = new SimpleSchema({
 var nameSchema = profileSchema.pick(['firstName', 'lastName']);
 ```
 
+Additionally, you can pass an object as the last argument to extend/overwrite properties inherited from the first schema. If the property does not exist on the first schema, it will be added in this case; if the property does exist on the first schema, it will be changed in this case.
+
+```js
+var nameSchema = profileSchema.pick(['firstName', 'lastName'], {firstName: {optional:true}});
+```
+
+
 ## The Object to Validate
 
 The object you pass in when validating can be a normal object, or it can be
@@ -335,7 +342,7 @@ That last point can be confusing, so let's look at a couple examples:
 * Say you have a required key "friends.address.city" but "friends.address" is
 optional. If "friends.address" is set in the object you're validating, but
 "friends.address.city" is not, there is a validation error. However, if
-"friends.address" is *not* set, then there is no validation error for 
+"friends.address" is *not* set, then there is no validation error for
 "friends.address.city" because the object it belongs to is not present.
 * If you have a required key "friends.$.name", but the `friends` array has
 no objects in the object you are validating, there is no validation error
@@ -361,8 +368,8 @@ the minimum Date for a field should be "today".
 ### exclusiveMin/exclusiveMax
 
 Set to `true` to indicate that the range of numeric values, as set by min/max,
-are to be treated as an exclusive range. Set to `false` (default) to treat ranges as 
-inclusive. 
+are to be treated as an exclusive range. Set to `false` (default) to treat ranges as
+inclusive.
 
 ### decimal
 
@@ -407,7 +414,7 @@ validated as well, so you must define all allowed properties in the schema. If t
 not possible or you don't care to validate the object's properties, use the
 `blackbox: true` option to skip validation for everything within the object.
 
-Custom object types are treated as blackbox objects by default. However, 
+Custom object types are treated as blackbox objects by default. However,
 when using collection2, you must ensure that the custom type is not lost
 between client and server. This can be done with a `transform` function that
 converts the generic Object to the custom object. Without this transformation,
@@ -463,7 +470,7 @@ function:
 you return undefined.
 * `value`: If isSet = true, this contains the field's current (requested) value
 in the document or modifier.
-* `operator`: If isSet = true and isUpdate = true, this contains the name of the 
+* `operator`: If isSet = true and isUpdate = true, this contains the name of the
 update operator in the modifier in which this field is being changed. For example,
 if the modifier were `{$set: {name: "Alice"}}`, in the autoValue function for
 the `name` field, `this.isSet` would be true, `this.value` would be "Alice",
@@ -614,7 +621,7 @@ check({admin: true}, mySchema); // throw a Match.Error
 
 There are three ways to attach custom validation methods:
 
-* To add a custom validation function that is called for all keys in all 
+* To add a custom validation function that is called for all keys in all
 defined schemas, use `SimpleSchema.addValidator(myFunction)`.
 * To add a custom validation function that is called for all keys for a
 specific SimpleSchema instance, use `mySimpleSchema.addValidator(myFunction)`.
@@ -759,7 +766,7 @@ method returns the normalized copy.
 
 ## Customizing Validation Messages
 
-To customize validation messages, pass a messages object to either 
+To customize validation messages, pass a messages object to either
 `SimpleSchema.messages()` or `mySimpleSchemaInstance.messages()`. Instance-specific
 messages are given priority over global messages.
 
@@ -858,7 +865,7 @@ portion and you want to specify a minimum date, `min` should be set to midnight
 UTC on the minimum date (inclusive).
 
 Following these rules ensures maximum interoperability with HTML5 date inputs
-and usually just makes sense. 
+and usually just makes sense.
 
 ## Collection2 and AutoForm
 
@@ -881,13 +888,13 @@ optional, and then use a custom function similar to this:
     optional: true,
     custom: function () {
       var shouldBeRequired = this.field('saleType').value == 1;
-    
+
       if (shouldBeRequired) {
         // inserts
         if (!this.operator) {
           if (!this.isSet || this.value === null || this.value === "") return "required";
         }
-    
+
         // updates
         else if (this.isSet) {
           if (this.operator === "$set" && this.value === null || this.value === "") return "required";

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -658,9 +658,20 @@ SimpleSchema.prototype.addValidator = SimpleSchema.prototype.validator = functio
 SimpleSchema.prototype.pick = function(/* arguments */) {
   var self = this;
   var args = _.toArray(arguments);
+  var last = _.last(args);
+  var amend = _.isObject(last) && !_.isArray(last) ? args.splice(-1,1)[0] : false;
   args.unshift(self._schema);
 
   var newSchema = _.pick.apply(null, args);
+
+  if(amend) {
+    _.each(newSchema, function(options,field){
+      if(amend[field] ){
+        newSchema[field] = _.extend(options, amend[field]);
+      }
+    });
+  }
+
   return new SimpleSchema(newSchema);
 };
 


### PR DESCRIPTION
Now we can do this:

```js
var profileSchema = new SimpleSchema({
  firstName: {type: String},
  lastName: {type: String},
  username: {type: String}
});

var nameSchema = profileSchema.pick(['firstName', 'lastName'], {firstName: {optional: true}});
```

So on nameSchema the firstName field will be optional, but on profileSchema the firstName field will be required.