### PR TITLE
Fixed typo in export options for humanize

### DIFF
--- a/package.js
+++ b/package.js
@@ -27,7 +27,7 @@ Package.on_use(function(api) {
     'simple-schema-context.js'
   ]);
   api.export(['SimpleSchema', 'MongoObject'], ['client', 'server']);
-  api.export('humanize', {testonly:true});
+  api.export('humanize', {testOnly:true});
 
 });
 


### PR DESCRIPTION
I noticed that humanize was now a global in my application.

This happened because I forgot to camelcase ```testonly``` in my previous PR