### PR TITLE
Added Email with TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ A simple, reactive schema validation smart package for Meteor.
 
 - [simple-schema](#simple-schema)
   - [Change Log](#change-log)
+    - [1.5.4](#154)
+    - [1.5.3](#153)
+    - [1.5.2](#152)
+    - [1.5.1](#151)
+    - [1.5.0](#150)
     - [1.4.0](#140)
     - [1.3.3](#133)
     - [1.3.2](#132)
@@ -87,6 +92,10 @@ A simple, reactive schema validation smart package for Meteor.
 ## Change Log
 
 NOTE: There was an accidental breaking change in v1.4.0. Probably only aldeed:collection2 is affected. If you use aldeed:simple-schema v1.4.0 or higher along with aldeed:collection2, be sure to use aldeed:collection2 v2.7.1 or higher.
+
+### 1.5.4
+
+Add `SimpleSchema.RegEx.EmailWithTLD`
 
 ### 1.5.3
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ an array of regular expressions that will be tested in order.
 The `SimpleSchema.RegEx` object defines standard regular
 expressions you can use as the value for the `regEx` key.
 - `SimpleSchema.RegEx.Email` for emails (uses a permissive regEx recommended by W3C, which most browsers use)
+- `SimpleSchema.RegEx.EmailWithTLD` for emails (the same like `Email` but needs a tld like `.com`)
 - `SimpleSchema.RegEx.Domain` for external domains and the domain only (requires a tld like `.com`)
 - `SimpleSchema.RegEx.WeakDomain` for less strict domains and IPv4 and IPv6
 - `SimpleSchema.RegEx.IP` for IPv4 or IPv6
@@ -997,7 +998,8 @@ Anyone is welcome to contribute. Fork, make and test your changes
 
 (Add your name if it's missing.)
 
-- @mquandalle
-- @Nemo64
+- [@mquandalle](https://github.com/mquandalle)
+- [@Nemo64](https://github.com/Nemo64)
+- [@ffflorian](https://github.com/ffflorian)
 
 [![Support via Gittip](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/aldeed/)

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "aldeed:simple-schema",
   summary: "A simple schema validation object with reactivity. Used by collection2 and autoform.",
-  version: "1.5.3",
+  version: "1.5.4",
   git: "https://github.com/aldeed/meteor-simple-schema.git"
 });
 

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -55,6 +55,10 @@ var ssr = new SimpleSchema({
     type: String,
     regEx: SimpleSchema.RegEx.Email
   },
+  requiredEmailWithTLD: {
+    type: String,
+    regEx: SimpleSchema.RegEx.EmailWithTLD
+  },
   requiredUrl: {
     type: String,
     regEx: SimpleSchema.RegEx.Url
@@ -81,6 +85,7 @@ var ssr = new SimpleSchema({
 
 ssr.messages({
   "regEx requiredEmail": "[label] is not a valid e-mail address",
+  "regEx requiredEmailWithTLD": "[label] is not a valid e-mail address",
   "regEx requiredUrl": "[label] is not a valid URL"
 });
 
@@ -486,6 +491,7 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Valid", function(test) {
     requiredNumber: 1,
     requiredDate: (new Date()),
     requiredEmail: "test123@sub.example.edu",
+    requiredEmailWithTLD: "test123@sub.example.edu",
     requiredUrl: "http://google.com",
     requiredObject: {
       requiredNumber: 1
@@ -502,6 +508,7 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Valid", function(test) {
     requiredNumber: 1,
     requiredDate: (new Date()),
     requiredEmail: "test123@sub.example.edu",
+    requiredEmailWithTLD: "test123@sub.example.edu",
     requiredUrl: "http://google.com",
     requiredObject: {
       requiredNumber: 1
@@ -512,7 +519,7 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Valid", function(test) {
 
 Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test) {
   var sc = validateNoClean(ssr, {});
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   sc = validateNoClean(ssr, {
     requiredString: null,
@@ -520,13 +527,14 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     optionalObject: {
       requiredString: null
     }
   });
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {
     requiredString: null,
@@ -534,11 +542,12 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     optionalObject: {}
   });
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {
     requiredString: null,
@@ -546,12 +555,13 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     optionalObject: null
   });
   // we should not get an error about optionalObject.requiredString because the whole object is null
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   sc = validateNoClean(ssr, {
     requiredString: null,
@@ -559,11 +569,12 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null
   });
   // we should not get an error about optionalObject.requiredString because the whole object is missing
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   sc = validateNoClean(ssr, {
     requiredString: void 0,
@@ -571,13 +582,14 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: void 0,
     requiredDate: void 0,
     requiredEmail: void 0,
+    requiredEmailWithTLD: void 0,
     requiredUrl: void 0,
     requiredObject: void 0,
     optionalObject: {
       requiredString: void 0
     }
   });
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {
     requiredString: "",
@@ -585,13 +597,14 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     optionalObject: {
       requiredString: ""
     }
   });
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 
   sc = validateNoClean(ssr, {
     requiredString: "   ",
@@ -599,13 +612,14 @@ Tinytest.add("SimpleSchema - Required Checks - Insert - Invalid", function(test)
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     optionalObject: {
       requiredString: "   "
     }
   });
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 
   //array of objects
   sc = validateNoClean(friends, {
@@ -626,6 +640,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - $set", function(
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -642,6 +657,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - $set", function(
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -658,6 +674,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - $setOnInsert", f
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -674,6 +691,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - $setOnInsert", f
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -694,6 +712,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - Combined", funct
     },
     $setOnInsert: {
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -712,6 +731,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - Combined", funct
     },
     $setOnInsert: {
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -724,16 +744,17 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Valid - Combined", funct
 
 Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $set", function(test) {
   var sc = validateNoClean(ssr, {$set: {}}, true, true, true);
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   // should be no different with some missing
   sc = validateNoClean(ssr, {$set: {
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': null
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {$set: {
       requiredString: null,
@@ -741,11 +762,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $set", functio
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': null
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {$set: {
       requiredString: void 0,
@@ -753,11 +775,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $set", functio
       requiredNumber: void 0,
       requiredDate: void 0,
       requiredEmail: void 0,
+      requiredEmailWithTLD: void 0,
       requiredUrl: void 0,
       requiredObject: void 0,
       'optionalObject.requiredString': void 0
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {$set: {
       requiredString: "",
@@ -765,11 +788,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $set", functio
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': ""
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 
   sc = validateNoClean(ssr, {$set: {
       requiredString: "   ",
@@ -777,16 +801,17 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $set", functio
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': "   "
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 });
 
 Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $setOnInsert", function(test) {
   var sc = validateNoClean(ssr, {$setOnInsert: {}}, true, true, true);
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   sc = validateNoClean(ssr, {$setOnInsert: {
       requiredString: null,
@@ -794,11 +819,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $setOnInsert",
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': null
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {$setOnInsert: {
       requiredString: void 0,
@@ -806,11 +832,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $setOnInsert",
       requiredNumber: void 0,
       requiredDate: void 0,
       requiredEmail: void 0,
+      requiredEmailWithTLD: void 0,
       requiredUrl: void 0,
       requiredObject: void 0,
       'optionalObject.requiredString': void 0
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {$setOnInsert: {
       requiredString: "",
@@ -818,11 +845,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $setOnInsert",
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': ""
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 
   sc = validateNoClean(ssr, {$setOnInsert: {
       requiredString: "   ",
@@ -830,11 +858,12 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - $setOnInsert",
       requiredNumber: null,
       requiredDate: null,
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': "   "
     }}, true, true, true);
-  test.length(sc.invalidKeys(), 7);
+  test.length(sc.invalidKeys(), 8);
 
   //array of objects
   sc = validateNoClean(friends, {$setOnInsert: {
@@ -848,7 +877,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
   //some in $set and some in $setOnInsert, make sure they're merged for validation purposes
 
   var sc = validateNoClean(ssr, {$setOnInsert: {}, $set: {}}, true, true, true);
-  test.length(sc.invalidKeys(), 8);
+  test.length(sc.invalidKeys(), 9);
 
   sc = validateNoClean(ssr, {
     $set: {
@@ -859,12 +888,13 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     },
     $setOnInsert: {
       requiredEmail: null,
+      requiredEmailWithTLD: null,
       requiredUrl: null,
       requiredObject: null,
       'optionalObject.requiredString': null
     }
   }, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {
     $set: {
@@ -875,12 +905,13 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     },
     $setOnInsert: {
       requiredEmail: void 0,
+      requiredEmailWithTLD: void 0,
       requiredUrl: void 0,
       requiredObject: void 0,
       'optionalObject.requiredString': void 0
     }
   }, true, true, true);
-  test.length(sc.invalidKeys(), 9);
+  test.length(sc.invalidKeys(), 10);
 
   sc = validateNoClean(ssr, {
     $set: {
@@ -891,6 +922,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     },
     $setOnInsert: {
       requiredEmail: "",
+      requiredEmailWithTLD: "",
       requiredUrl: "",
       requiredObject: null,
       'optionalObject.requiredString': ""
@@ -909,7 +941,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     }
     return memo;
   }, 0);
-  test.equal(regExErrorCount, 2);
+  test.equal(regExErrorCount, 3);
 
   sc = validateNoClean(ssr, {
     $set: {
@@ -920,6 +952,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     },
     $setOnInsert: {
       requiredEmail: "   ",
+      requiredEmailWithTLD: "   ",
       requiredUrl: "   ",
       requiredObject: null,
       'optionalObject.requiredString': "   "
@@ -938,7 +971,7 @@ Tinytest.add("SimpleSchema - Required Checks - Upsert - Invalid - Combined", fun
     }
     return memo;
   }, 0);
-  test.equal(regExErrorCount, 2);
+  test.equal(regExErrorCount, 3);
 });
 
 Tinytest.add("SimpleSchema - Required Checks - Update - Valid - $set", function(test) {
@@ -951,6 +984,7 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Valid - $set", function(
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       'requiredObject.requiredNumber': 1,
       'optionalObject.requiredString': "test"
@@ -963,6 +997,7 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Valid - $set", function(
       requiredNumber: 1,
       requiredDate: (new Date()),
       requiredEmail: "test123@sub.example.edu",
+      requiredEmailWithTLD: "test123@sub.example.edu",
       requiredUrl: "http://google.com",
       requiredObject: {
         requiredNumber: 1
@@ -996,10 +1031,11 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Invalid - $set", functio
     requiredNumber: void 0,
     requiredDate: void 0,
     requiredEmail: void 0,
+    requiredEmailWithTLD: void 0,
     requiredUrl: void 0,
     requiredObject: void 0,
     'optionalObject.requiredString': void 0
-  }}, 9);
+  }}, 10);
 
   t(ssr, {$set: {
     requiredString: null,
@@ -1007,10 +1043,11 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Invalid - $set", functio
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     'optionalObject.requiredString': null
-  }}, 9);
+  }}, 10);
 
   t(ssr, {$set: {
     requiredString: "",
@@ -1018,10 +1055,11 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Invalid - $set", functio
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     'optionalObject.requiredString': ""
-  }}, 7);
+  }}, 8);
 
   t(ssr, {$set: {
     requiredString: "   ",
@@ -1029,10 +1067,11 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Invalid - $set", functio
     requiredNumber: null,
     requiredDate: null,
     requiredEmail: null,
+    requiredEmailWithTLD: null,
     requiredUrl: null,
     requiredObject: null,
     'optionalObject.requiredString': "   "
-  }}, 7);
+  }}, 8);
 
   //array of objects
 
@@ -1090,9 +1129,10 @@ Tinytest.add("SimpleSchema - Required Checks - Update - Invalid - $unset", funct
       requiredNumber: 1,
       requiredDate: 1,
       requiredEmail: 1,
+      requiredEmailWithTLD: 1,
       requiredUrl: 1
     }}, true);
-  test.length(sc.invalidKeys(), 6);
+  test.length(sc.invalidKeys(), 7);
 
   //array of objects
   sc = validateNoClean(friends, {$unset: {
@@ -2856,7 +2896,7 @@ Tinytest.add("SimpleSchema - Array of Objects", function(test) {
 Tinytest.add("SimpleSchema - Multiple Contexts", function(test) {
   var ssContext1 = ssr.newContext();
   ssContext1.validate({});
-  test.length(ssContext1.invalidKeys(), 8);
+  test.length(ssContext1.invalidKeys(), 9);
   var ssContext2 = ssr.newContext();
   ssContext2.validate({
     requiredString: "test",
@@ -2864,6 +2904,7 @@ Tinytest.add("SimpleSchema - Multiple Contexts", function(test) {
     requiredNumber: 1,
     requiredDate: (new Date()),
     requiredEmail: "test123@sub.example.edu",
+    requiredEmailWithTLD: "test123@sub.example.edu",
     requiredUrl: "http://google.com",
     requiredObject: {
       requiredNumber: 1
@@ -2872,7 +2913,7 @@ Tinytest.add("SimpleSchema - Multiple Contexts", function(test) {
       requiredString: "test"
     }
   });
-  test.length(ssContext1.invalidKeys(), 8);
+  test.length(ssContext1.invalidKeys(), 9);
   test.length(ssContext2.invalidKeys(), 0);
 });
 

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -535,6 +535,7 @@ SimpleSchema.RegEx = {
   // This is probably the same logic used by most browsers when type=email, which is our goal. It is
   // a very permissive expression. Some apps may wish to be more strict and can write their own RegExp.
   Email: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+  EmailWithTLD: /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+(?:\.[A-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:[A-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[A-z0-9]{2,}(?:[a-z0-9-]*[a-z0-9])?$/,
 
   Domain: new RegExp('^' + RX_DOMAIN + '$'),
   WeakDomain: new RegExp('^' + RX_WEAK_DOMAIN + '$'),
@@ -930,6 +931,7 @@ SimpleSchema._globalMessages = {
   regEx: [
     {msg: "[label] failed regular expression validation"},
     {exp: SimpleSchema.RegEx.Email, msg: "[label] must be a valid e-mail address"},
+    {exp: SimpleSchema.RegEx.EmailWithTLD, msg: "[label] must be a valid e-mail address"},
     {exp: SimpleSchema.RegEx.WeakEmail, msg: "[label] must be a valid e-mail address"},
     {exp: SimpleSchema.RegEx.Domain, msg: "[label] must be a valid domain"},
     {exp: SimpleSchema.RegEx.WeakDomain, msg: "[label] must be a valid domain"},


### PR DESCRIPTION
Hi,
based on the idea of issue [#224](https://github.com/aldeed/meteor-simple-schema/issues/224#issuecomment-79794943) I created a new RegEx `SimpleSchema.RegEx.EmailWithTLD` which can be used instead of `SimpleSchema.RegEx.Email`

I'd be happy to see this being released!