### PR TITLE
Fix validateOne not working on array fields

### DIFF
--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -217,7 +217,8 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
       def = ss.getDefinition(affectedKey);
 
       // Perform validation for this key
-      if (!keyToValidate || keyToValidate === affectedKey || keyToValidate === affectedKeyGeneric) {
+      var validateArrayItem = (keyToValidate && affectedKeyGeneric.match(new RegExp(keyToValidate + '\\.\\$', 'i')));
+      if (!keyToValidate || keyToValidate === affectedKey || keyToValidate === affectedKeyGeneric || validateArrayItem) {
         // We can skip the required check for keys that are ancestors
         // of those in $set or $setOnInsert because they will be created
         // by MongoDB while setting.


### PR DESCRIPTION
Fixes issue #360 

This adds array support to ```validateOne```. Also works with AutoForm's ``validateField`` method.

Fixes validation to properly validate array items when attempting to validate the root array field itself. 
Adds duplicate invalid key checking and marks invalid array items as changed.

Please check the ``simple-schema-validation.js`` modifications to make sure there won't be side effects.