### PR TITLE
.clean method bug with nested object fields containing the numbers at beginning of key

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -275,8 +275,7 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
         if (current[subkey] === void 0 && value !== void 0) {
           //see if the next piece is a number
           nextPiece = subkeys[i + 1];
-          nextPiece = parseInt(nextPiece, 10);
-          current[subkey] = isNaN(nextPiece) ? {} : [];
+          current[subkey] = isNaN(+nextPiece) ? {} : [];
         }
 
         // Move deeper into the object

--- a/mongo-object.js
+++ b/mongo-object.js
@@ -712,9 +712,8 @@ MongoObject.expandKey = function(val, key, obj) {
     } else {
       //see if the next piece is a number
       nextPiece = subkeys[i + 1];
-      nextPiece = parseInt(nextPiece, 10);
       if (!current[subkey]) {
-        current[subkey] = isNaN(nextPiece) ? {} : [];
+        current[subkey] = isNaN(+nextPiece) ? {} : [];
       }
     }
     current = current[subkey];


### PR DESCRIPTION
``` javascript
new SimpleSchema({
  obj: { type:Object },
  "obj.1abc": { type: String, defaultValue: "testValue" }
}).clean({})
```

Interprets the `obj` field as array with field `1abc` instead of object. Namely, we gets:

``` javascript
{ obj: [] }
```

instead of:

``` javascript
{
  obj: { 1abc: "testValue"  }
}
```

Because `parseInt("1abc", 10)` returns the number `1` not `NaN`.
