### PR TITLE
Add hashmap objects validation

### DIFF
--- a/mongo-object.js
+++ b/mongo-object.js
@@ -40,7 +40,9 @@ var makeGeneric = function makeGeneric(name) {
   if (typeof name !== "string") {
     return null;
   }
-  return name.replace(/\.[0-9]+\./g, '.$.').replace(/\.[0-9]+$/g, '.$');
+  var genericName = name.replace(/\.[0-9]+(?=\.|$)/g, '.$');
+  genericName = genericName.replace(/\.@#(.*?)#@/g, '.*');
+  return genericName;
 };
 
 var appendAffectedKey = function appendAffectedKey(affectedKey, key) {
@@ -68,8 +70,13 @@ var extractOp = function extractOp(position) {
  * upon creation of the instance, the object will have any `undefined` keys
  * removed recursively.
  */
-MongoObject = function(objOrModifier, blackBoxKeys) {
+MongoObject = function(objOrModifier, simpleSchema) {
   var self = this;
+  self._simpleSchema = simpleSchema;
+  var blackBoxKeys = [];
+  if (simpleSchema) {
+    blackBoxKeys = simpleSchema._blackBoxKeys;
+  }
   self._obj = objOrModifier;
   self._affectedKeys = {};
   self._genericAffectedKeys = {};
@@ -114,7 +121,13 @@ MongoObject = function(objOrModifier, blackBoxKeys) {
       }
 
       // Make generic key
-      affectedKeyGeneric = makeGeneric(affectedKey);
+      if (self._simpleSchema) {
+        affectedKeyGeneric = self._simpleSchema.makeGeneric(affectedKey);
+      }
+      else {
+        affectedKeyGeneric = makeGeneric(affectedKey);
+      }
+
 
       // Determine whether affected key should be treated as a black box
       affectedKeyIsBlackBox = _.contains(blackBoxKeys, affectedKeyGeneric);
@@ -752,4 +765,3 @@ MongoObject._positionToKey = function positionToKey(position) {
   mDoc = null;
   return key;
 };
-

--- a/mongo-object.js
+++ b/mongo-object.js
@@ -62,7 +62,7 @@ var extractOp = function extractOp(position) {
 /*
  * @constructor
  * @param {Object} objOrModifier
- * @param {string[]} blackBoxKeys - A list of the names of keys that shouldn't be traversed
+ * @param {SimpleSchema} simpleSchema - A SimpleSchema instance
  * @returns {undefined}
  *
  * Creates a new MongoObject instance. The object passed as the first argument
@@ -75,7 +75,7 @@ MongoObject = function(objOrModifier, simpleSchema) {
   self._simpleSchema = simpleSchema;
   var blackBoxKeys = [];
   if (simpleSchema) {
-    blackBoxKeys = simpleSchema._blackBoxKeys;
+    blackBoxKeys = simpleSchema._blackboxKeys;
   }
   self._obj = objOrModifier;
   self._affectedKeys = {};

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "aldeed:simple-schema",
   summary: "A simple schema validation object with reactivity. Used by collection2 and autoform.",
-  version: "1.5.3",
+  version: "1.6.0",
   git: "https://github.com/aldeed/meteor-simple-schema.git"
 });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "aldeed:simple-schema",
   summary: "A simple schema validation object with reactivity. Used by collection2 and autoform.",
-  version: "1.6.0",
+  version: "1.5.4",
   git: "https://github.com/aldeed/meteor-simple-schema.git"
 });
 

--- a/package.js
+++ b/package.js
@@ -16,7 +16,7 @@ Package.on_use(function(api) {
     api.use(['deps', 'underscore', 'check', 'random']);
   }
 
-  api.use('mdg:validation-error@0.2.0', {unordered: true});
+  api.use('mdg:validation-error@0.5.0', {unordered: true});
 
   api.add_files([
     'string-polyfills.js',

--- a/package.js
+++ b/package.js
@@ -16,7 +16,7 @@ Package.on_use(function(api) {
     api.use(['deps', 'underscore', 'check', 'random']);
   }
 
-  api.use('mdg:validation-error@0.5.0', {unordered: true});
+  api.use('mdg:validation-error@0.2.0', {unordered: true});
 
   api.add_files([
     'string-polyfills.js',

--- a/simple-schema-context.js
+++ b/simple-schema-context.js
@@ -148,7 +148,7 @@ SimpleSchemaValidationContext.prototype._markKeysChanged = function simpleSchema
   }
 
   _.each(keys, function(name) {
-    var genericName = SimpleSchema._makeGeneric(name);
+    var genericName = self._simpleSchema.makeGeneric(name);
     if (genericName in self._deps) {
       self._deps[genericName].changed();
     }
@@ -158,7 +158,7 @@ SimpleSchemaValidationContext.prototype._markKeysChanged = function simpleSchema
 
 SimpleSchemaValidationContext.prototype._getInvalidKeyObject = function simpleSchemaValidationContextGetInvalidKeyObject(name, genericName) {
   var self = this;
-  genericName = genericName || SimpleSchema._makeGeneric(name);
+  genericName = genericName || self._simpleSchema.makeGeneric(name);
 
   var errorObj = _.findWhere(self._invalidKeys, {name: name});
   if (!errorObj) {
@@ -173,14 +173,16 @@ SimpleSchemaValidationContext.prototype._keyIsInvalid = function simpleSchemaVal
 
 // Like the internal one, but with deps
 SimpleSchemaValidationContext.prototype.keyIsInvalid = function simpleSchemaValidationContextKeyIsInvalid(name) {
-  var self = this, genericName = SimpleSchema._makeGeneric(name);
+  var self = this;
+  var genericName = self._simpleSchema.makeGeneric(name);
   self._deps[genericName] && self._deps[genericName].depend();
 
   return self._keyIsInvalid(name, genericName);
 };
 
 SimpleSchemaValidationContext.prototype.keyErrorMessage = function simpleSchemaValidationContextKeyErrorMessage(name) {
-  var self = this, genericName = SimpleSchema._makeGeneric(name);
+  var self = this;
+  var genericName = self._simpleSchema.makeGeneric(name);
   self._deps[genericName] && self._deps[genericName].depend();
 
   var errorObj = self._getInvalidKeyObject(name, genericName);

--- a/simple-schema-context.js
+++ b/simple-schema-context.js
@@ -182,12 +182,12 @@ SimpleSchemaValidationContext.prototype.keyIsInvalid = function simpleSchemaVali
 SimpleSchemaValidationContext.prototype.keyErrorMessage = function simpleSchemaValidationContextKeyErrorMessage(name) {
   var self = this, genericName = SimpleSchema._makeGeneric(name);
   self._deps[genericName] && self._deps[genericName].depend();
-  
+
   var errorObj = self._getInvalidKeyObject(name, genericName);
   if (!errorObj) {
     return "";
   }
-  
+
   return self._simpleSchema.messageForError(errorObj.type, errorObj.name, null, errorObj.value);
 };
 

--- a/simple-schema-utility.js
+++ b/simple-schema-utility.js
@@ -15,6 +15,9 @@ Utility = {
     return !_.contains(["$pull", "$pullAll", "$pop", "$slice"], key);
   },
   errorObject: function errorObject(errorType, keyName, keyValue) {
+    if (keyName.match(/@#(.*?)#@/g)) {
+      keyName = keyName.split(/@#(.*?)#@/g).join('');
+    }
     return {name: keyName, type: errorType, value: keyValue};
   },
   // Tests whether it's an Object as opposed to something that inherits from Object

--- a/simple-schema-utility.js
+++ b/simple-schema-utility.js
@@ -15,9 +15,6 @@ Utility = {
     return !_.contains(["$pull", "$pullAll", "$pop", "$slice"], key);
   },
   errorObject: function errorObject(errorType, keyName, keyValue) {
-    if (keyName.match(/@#(.*?)#@/g)) {
-      keyName = keyName.split(/@#(.*?)#@/g).join('');
-    }
     return {name: keyName, type: errorType, value: keyValue};
   },
   // Tests whether it's an Object as opposed to something that inherits from Object

--- a/simple-schema-validation-new.js
+++ b/simple-schema-validation-new.js
@@ -244,11 +244,23 @@ doValidation2 = function doValidation2(obj, isModifier, isUpsert, keyToValidate,
       });
     }
 
+    // Validate hashmaps
     if (Utility.isBasicObject(val) && def && def.hashmap) {
+      var fixedKeys = def.fixedKeys || [];
+      var hashmapVal = _.omit(val, fixedKeys);
       _.each(val, function (v, i) {
-        _.each(v, function (val, key) {
-          checkObj(val, affectedKey + '.*.' + key, operator, setKeys);
+        var composedAffectedKey = affectedKey + '.@#' + i + '#@';
+        if (_.contains(fixedKeys, i)){
+          composedAffectedKey = affectedKey + '.' + i;
+        }
+        _.each(v, function (value, key) {
+          if (Utility.isBasicObject(v)) {
+            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false);
+          }
         });
+        if (!Utility.isBasicObject(v)) {
+          checkObj(v, composedAffectedKey, operator, setKeys, false, false);
+        }
       });
     }
 

--- a/simple-schema-validation-new.js
+++ b/simple-schema-validation-new.js
@@ -244,8 +244,16 @@ doValidation2 = function doValidation2(obj, isModifier, isUpsert, keyToValidate,
       });
     }
 
+    if (Utility.isBasicObject(val) && def && def.hashmap) {
+      _.each(val, function (v, i) {
+        _.each(v, function (val, key) {
+          checkObj(val, affectedKey + '.*.' + key, operator, setKeys);
+        });
+      });
+    }
+
     // Loop through object keys
-    else if (Utility.isBasicObject(val) && (!def || !def.blackbox)) {
+    else if (Utility.isBasicObject(val) && (!def || !def.blackbox || !def.hashmap)) {
 
       // Get list of present keys
       var presentKeys = _.keys(val);
@@ -290,7 +298,7 @@ function convertModifierToDoc(mod, schema, isUpsert) {
   var t = new Meteor.Collection(null);
 
   // LocalCollections are in memory, and it seems
-  // that it's fine to use them synchronously on 
+  // that it's fine to use them synchronously on
   // either client or server
   var id;
   if (isUpsert) {
@@ -341,7 +349,7 @@ function convertModifierToDoc(mod, schema, isUpsert) {
     // Now update it with the modifier
     t.update(id, mod);
   }
-  
+
   var doc = t.findOne(id);
   // We're done with it
   t.remove(id);

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -256,6 +256,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
             checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false);
           }
         });
+        // TODO: Add check of deeper keys to empty if object is empty
         if (!Utility.isBasicObject(v)) {
           checkObj(v, composedAffectedKey, operator, setKeys, false, false);
         }

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -242,8 +242,17 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
       });
     }
 
+    if (Utility.isBasicObject(val) && def && def.hashmap) {
+      _.each(val, function (v, i) {
+        _.each(v, function (val, key) {
+          checkObj(val, affectedKey + '.*.' + key, operator, setKeys);
+        });
+
+      });
+    }
+
     // Loop through object keys
-    else if (Utility.isBasicObject(val) && (!def || !def.blackbox)) {
+    else if (Utility.isBasicObject(val) && (!def || !def.blackbox || !def.hashmap)) {
 
       // Get list of present keys
       var presentKeys = _.keys(val);

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -245,7 +245,6 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
     // Validate hashmaps
     if (Utility.isBasicObject(val) && def && def.hashmap) {
       var fixedKeys = def.fixedKeys || [];
-      var hashmapVal = _.omit(val, fixedKeys);
       _.each(val, function (v, i) {
         var composedAffectedKey = affectedKey + '.@#' + i + '#@';
         if (_.contains(fixedKeys, i)){
@@ -253,12 +252,19 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
         }
         _.each(v, function (value, key) {
           if (Utility.isBasicObject(v)) {
-            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false);
+            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys);
           }
         });
         // TODO: Add check of deeper keys to empty if object is empty
+        if (Utility.isBasicObject(v) && _.isEmpty(v)) {
+          var composedGenericAffectedKey = SimpleSchema._makeGeneric(composedAffectedKey);
+          var childKeys = ss.objectKeys(composedGenericAffectedKey);
+          _.each(childKeys, function(childKey) {
+            checkObj(v[childKey], composedAffectedKey + '.' + childKey, operator,setKeys);
+          });
+        }
         if (!Utility.isBasicObject(v)) {
-          checkObj(v, composedAffectedKey, operator, setKeys, false, false);
+          checkObj(v, composedAffectedKey, operator, setKeys);
         }
       });
     }

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -202,7 +202,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
   }
 
   // The recursive function
-  function checkObj(val, affectedKey, operator, setKeys, isInArrayItemObject, isInSubObject, overrides) {
+  function checkObj(val, affectedKey, operator, setKeys, isInArrayItemObject, isInSubObject, genericKeys) {
     var affectedKeyGeneric, def;
 
     if (affectedKey) {
@@ -214,7 +214,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
       // Make a generic version of the affected key, and use that
       // to get the schema for this key.
       affectedKeyGeneric = SimpleSchema._makeGeneric(affectedKey);
-      def = _.extend(ss.getDefinition(affectedKey), overrides);
+      def = ss.getDefinition(affectedKey);
 
       // Perform validation for this key
       if (!keyToValidate || keyToValidate === affectedKey || keyToValidate === affectedKeyGeneric) {
@@ -244,15 +244,15 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
 
     // Validate hashmaps
     if (Utility.isBasicObject(val) && def && def.hashmap) {
-      var composedAffectedKey = affectedKey + '.*';
       _.each(val, function (v, i) {
+        var composedAffectedKey = affectedKey + '.@#' + i + '#@';
         _.each(v, function (value, key) {
           if (Utility.isBasicObject(v)) {
-            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false, { hashKey: key});
+            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false, genericKeys);
           }
         });
         if (!Utility.isBasicObject(v)) {
-          checkObj(v, composedAffectedKey, operator, setKeys, false, false, { hashKey: i });
+          checkObj(v, composedAffectedKey, operator, setKeys, false, false, genericKeys);
         }
       });
     }

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -56,6 +56,10 @@ function doTypeChecks(def, keyValue, op) {
   else if (expectedType === Object) {
     if (!Utility.isBasicObject(keyValue)) {
       return "expectedObject";
+    } else if (def.minCount !== null && def.hashmap === true && _.size(keyValue) < def.minCount) {
+      return "minCount";
+    } else if (def.maxCount !== null && def.hashmap === true && _.size(keyValue) > def.maxCount) {
+      return "maxCount";
     }
   }
 
@@ -252,11 +256,12 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
         }
 
         if (Utility.isBasicObject(v)) {
-          _.each(v, function (value, key) {
-              checkObj(value, composedAffectedKey + '.' + key, operator, setKeys);
+          // Check all the possible keys
+          var keysToCheck = ss.objectKeys(ss.makeGeneric(composedAffectedKey));
+          _.each(keysToCheck, function (key) {
+              checkObj(v[key], composedAffectedKey + '.' + key, operator, setKeys);
           });
         }
-        // TODO: Add check of deeper keys to empty if object is empty
 
         if (Utility.isBasicObject(v) && _.isEmpty(v)) {
           var composedGenericAffectedKey = ss.makeGeneric(composedAffectedKey);

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -202,7 +202,7 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
   }
 
   // The recursive function
-  function checkObj(val, affectedKey, operator, setKeys, isInArrayItemObject, isInSubObject, genericKeys) {
+  function checkObj(val, affectedKey, operator, setKeys, isInArrayItemObject, isInSubObject) {
     var affectedKeyGeneric, def;
 
     if (affectedKey) {
@@ -244,15 +244,20 @@ doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValidate,
 
     // Validate hashmaps
     if (Utility.isBasicObject(val) && def && def.hashmap) {
+      var fixedKeys = def.fixedKeys || [];
+      var hashmapVal = _.omit(val, fixedKeys);
       _.each(val, function (v, i) {
         var composedAffectedKey = affectedKey + '.@#' + i + '#@';
+        if (_.contains(fixedKeys, i)){
+          composedAffectedKey = affectedKey + '.' + i;
+        }
         _.each(v, function (value, key) {
           if (Utility.isBasicObject(v)) {
-            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false, genericKeys);
+            checkObj(value, composedAffectedKey + '.' + key, operator, setKeys, false, false);
           }
         });
         if (!Utility.isBasicObject(v)) {
-          checkObj(v, composedAffectedKey, operator, setKeys, false, false, genericKeys);
+          checkObj(v, composedAffectedKey, operator, setKeys, false, false);
         }
       });
     }

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -20,7 +20,8 @@ var schemaDefinition = {
   blackbox: Match.Optional(Boolean),
   autoValue: Match.Optional(Function),
   defaultValue: Match.Optional(Match.Any),
-  trim: Match.Optional(Boolean)
+  trim: Match.Optional(Boolean),
+  hashmap: Match.Optional(Boolean)
 };
 
 /*

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -564,8 +564,9 @@ SimpleSchema._makeGeneric = function(name) {
   if (typeof name !== "string") {
     return null;
   }
-
-  return name.replace(/\.[0-9]+(?=\.|$)/g, '.$');
+  var genericName = name.replace(/\.[0-9]+(?=\.|$)/g, '.$');
+  genericName = genericName.replace(/\.@#(.*?)#@/g, '.*');
+  return genericName;
 };
 
 SimpleSchema._depsGlobalMessages = new Deps.Dependency();

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -21,7 +21,8 @@ var schemaDefinition = {
   autoValue: Match.Optional(Function),
   defaultValue: Match.Optional(Match.Any),
   trim: Match.Optional(Boolean),
-  hashmap: Match.Optional(Boolean)
+  hashmap: Match.Optional(Boolean),
+  fixedKeys: Match.Optional([String])
 };
 
 /*


### PR DESCRIPTION
## What is this PR doing?

Is adding hashmap objects validation, in order to validate objects like this:

``` js
var schema = new SimpleSchema({
    obj: {
        type: Object,
        hashmap: true,
        fixedKeys: ['fixed1', 'fixed2']
    },
    'obj.*': {
        type: Object,
        hashmap: true,
        fixedKeys: ['deepFixed']
    },
    'obj.*.test': {
        type: Boolean,
    },
    'obj.*.deepFixed': {
        type: Object,
        hashmap: true  
    },
    'obj.*.deepFixed.*.aTest': {
        type: String
    },
    'obj.fixed1': {
        type: Number
    },
    'obj.fixed2': {
        type: [Number]
    }
});

var o = {
    obj: {
        key1: {
            test: true,
            deepFixed: {

            }
        },
        key2: {
            test: true,
            deepFixed: {
                key1: {
                }
            }
        },
        fixed1: 1,
        fixed2: [1,2,3,4] 
    }
};
```

It throws errros with the real keypath not with the generic one, just like arrays.

![image](https://cloud.githubusercontent.com/assets/6980777/15626986/a00c48e2-24d5-11e6-8d5b-760d6e84e9d5.png)
