### PR TITLE
remove/noDecimal of Number checks

### DIFF
--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -40,8 +40,6 @@ function doTypeChecks(def, keyValue, op) {
        return !!def.exclusiveMax ? "maxNumberExclusive" : "maxNumber";
     } else if (op !== "$inc" && def.min !== null && (!!def.exclusiveMin ? def.min >= keyValue : def.min > keyValue)) {
        return !!def.exclusiveMin ? "minNumberExclusive" : "minNumber";
-    } else if (!def.decimal && keyValue.toString().indexOf(".") > -1) {
-      return "noDecimal";
     }
   }
 


### PR DESCRIPTION
Validation was very inconvenient not to pass a decimal.
Since the JavaScript decimal is also at Number I thought decimal also pass the validation.
So I changed the validation to pass a decimal.
