### PR TITLE
Updated 2.0-changelog to include removing of array-brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ NOTE: There was an accidental breaking change in v1.4.0. Probably only aldeed:co
   - `validationContext.validateOne()`: Instead you can pass a `keys` array as an option to `validationContext.validate()`.
 - Other Breaking Changes:
   - `decimal` is no longer a valid schema option. Instead, decimal/float is the default, and you can set the `type` to `SimpleSchema.Integer` to specify that you want only integers.
+  - The syntax of array-brackets `new SimpleSchema({ foo: { type: [String] } })` has been replaced by a more declarative solution: `new SimpleSchema({ foo: { type: Array }, 'foo.$': { type: String } })`
   - Error message changes:
     - SimpleSchema now uses `MessageBox` to manage validation error messages. Among other things, this means that placeholder text should now use handlebars syntax, `{{label}}` instead of `[label]`
     - In the message context (for placeholders), `[type]` is now `{{dataType}}` and `[key]` is now `{{name}}`, though `key` still works for now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ NOTE: There was an accidental breaking change in v1.4.0. Probably only aldeed:co
   - `validationContext.validateOne()`: Instead you can pass a `keys` array as an option to `validationContext.validate()`.
 - Other Breaking Changes:
   - `decimal` is no longer a valid schema option. Instead, decimal/float is the default, and you can set the `type` to `SimpleSchema.Integer` to specify that you want only integers.
-  - The syntax of array-brackets `new SimpleSchema({ foo: { type: [String] } })` has been replaced by a more declarative solution: `new SimpleSchema({ foo: { type: Array }, 'foo.$': { type: String } })`
+  - The syntax of array-brackets `new SimpleSchema({ foo: { type: [String] } })` has been replaced by a more declarative solution: `new SimpleSchema({ foo: { type: Array }, 'foo.$': { type: String } })`. This only applies when defining the full type. The short version `new SimpleSchema({ foo: [String] })` is still valid.
   - Error message changes:
     - SimpleSchema now uses `MessageBox` to manage validation error messages. Among other things, this means that placeholder text should now use handlebars syntax, `{{label}}` instead of `[label]`
     - In the message context (for placeholders), `[type]` is now `{{dataType}}` and `[key]` is now `{{name}}`, though `key` still works for now.


### PR DESCRIPTION
Noted the removing of the array-brackets in v2.0

This is linked to https://github.com/aldeed/node-simple-schema/pull/167 where I removed it from the `Readme.md` of the node package. Take a look at it for further information.